### PR TITLE
Add mime types gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ PATH
       andand
       fog
       foreman
+      mime-types
       mysql2
       oj
       progressbar
@@ -151,11 +152,12 @@ GEM
     ipaddress (0.8.0)
     json (1.8.3)
     method_source (0.8.2)
+    mime-types (2.6.1)
     mini_portile (0.6.2)
     minitest (5.8.3)
     mono_logger (1.1.0)
     multi_json (1.11.2)
-    mysql2 (0.4.1)
+    mysql2 (0.4.2)
     nokogiri (1.6.6.4)
       mini_portile (~> 0.6.0)
     oj (2.13.1)

--- a/km-db.gemspec
+++ b/km-db.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 2.4.0'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'pry'
-  
+
   s.add_dependency 'oj'
   s.add_dependency 'progressbar'
   s.add_dependency 'andand'
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'resque'
   s.add_dependency 'resque-lock'
   s.add_dependency 'foreman'
+  s.add_dependency 'mime-types'
   s.add_dependency 'fog'
   s.add_dependency 'mysql2'
 


### PR DESCRIPTION
:boom: This causes fog to exit because the mime-types gem was missing.
:ambulance: So let's fix that.